### PR TITLE
Save the enormous cost of serializing and deserializing

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "tape": "^4.2.2"
   },
   "dependencies": {
+    "alt": "^0.17.9",
     "react-pure-render": "^1.0.2"
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import PureComponent from 'react-pure-render/component';
+import { snapshot } from 'alt/lib/utils/StateFunctions';
 
 // Default `fn` property names
 // can vary on browsers
@@ -24,7 +25,7 @@ export default function connectToStores(reducer) {
 
       takeSnapshot() {
         const { flux } = this.context;
-        return JSON.parse(flux.takeSnapshot());
+        return snapshot(flux);
       }
 
       handleStoresChange = () =>


### PR DESCRIPTION
I ran across connect-alt in isomorphic-flux-boilerplate and I was so impressed with the simple elegance of this approach I started to think about using it everywhere.  I didn't expect it to be the fastest approach but the stringify() calls in takeSnapshot() are startlingly expensive.  Is there any advantage for this utility of passing the application state through JSON or can't the snapshot stay in Javascript land?

If there's an important reason to pass through a serialized form that's fine .. but flux.deserialize(...) would be more appropriate than JSON.parse(...) in the case someone has customized the serialize(...) call made in takeSnapshot().
