### PR TITLE
feat: support selective store listen with reducer function

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -29,6 +29,13 @@ export default function connectToStores(...connectArgs) {
             connectType: 'reducerFn',
             customProps: connectArgs[0](this.takeSnapshot())
           };
+        } else if (typeof connectArgs[connectArgs.length - 1] === 'function') {
+          // if we have a reducer fn as the last arg we
+          // will call this fn on the full alt state
+          this.state = {
+            connectType: 'storesReducerFn',
+            customProps: connectArgs[connectArgs.length - 1](this.takeSnapshot()),
+          };
         } else if (typeof connectArgs[0] === 'string') {
           // if it's string it will be stores names,
           // we want to provide the stores state into props
@@ -73,6 +80,17 @@ export default function connectToStores(...connectArgs) {
               return storeListener();
             });
             break;
+          case 'storesReducerFn':
+            // bind every specified store to the handleStoresChange listener
+            connectArgs.forEach((storeName) => {
+              if (typeof storeName === 'string') {
+                flux.getStore(storeName).listen(this.handleStoresChange);
+              }
+            });
+            // a store update may have been updated between state
+            // initialization and listening for changes from store
+            this.handleStoresChange();
+            break;
         }
 
       }
@@ -94,6 +112,15 @@ export default function connectToStores(...connectArgs) {
             });
             this.listeners = null;
             break;
+          case 'storesReducerFn':
+            connectArgs.forEach(storeName => {
+              if (typeof storeName === 'string') {
+                flux.getStore(storeName).unlisten(this.handleStoresChange);
+              }
+            });
+            this.listeners = null;
+            break;
+
         }
       }
 
@@ -111,7 +138,7 @@ export default function connectToStores(...connectArgs) {
       handleStoresChange = () => {
         return this.setState({
           ...this.state,
-          customProps: connectArgs[0](this.takeSnapshot())
+          customProps: connectArgs[connectArgs.length - 1](this.takeSnapshot()),
         });
       }
 

--- a/src/main.js
+++ b/src/main.js
@@ -34,7 +34,7 @@ export default function connectToStores(...connectArgs) {
           // will call this fn on the full alt state
           this.state = {
             connectType: 'storesReducerFn',
-            customProps: connectArgs[connectArgs.length - 1](this.takeSnapshot()),
+            customProps: connectArgs[connectArgs.length - 1](this.takeSnapshot())
           };
         } else if (typeof connectArgs[0] === 'string') {
           // if it's string it will be stores names,
@@ -138,7 +138,7 @@ export default function connectToStores(...connectArgs) {
       handleStoresChange = () => {
         return this.setState({
           ...this.state,
-          customProps: connectArgs[connectArgs.length - 1](this.takeSnapshot()),
+          customProps: connectArgs[connectArgs.length - 1](this.takeSnapshot())
         });
       }
 


### PR DESCRIPTION
The recent enhancements to `connect-alt` have been awesome!  I propose a hybrid of the two current operating modes.
- Allow subscription to named stores AND respond by providing custom reduced application state to the decorated component.
- Combines the efficiency of selective store subscription with the elegance of a reducer.
- Also, the "final" store monitors action dispatches; therefore it will not trigger an event when I use `this.emitChange()` on an async event triggering a change to my store.  With "direct" `listen` to stores this problem is also ameliorated.

Please feel free to change this in any way you'd like but please consider the idea.  Thanks!
