### PR TITLE
fix: remove Array.prototype.includes

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -139,7 +139,7 @@ export default function connectToStores(...connectArgs) {
     // usefull is you define `onEnter` hook for `react-router`
     Object.getOwnPropertyNames(DecoratedComponent).forEach(function(prop) {
       // Copy only fn and not defined ones on `ConnectToStoresWrapper`
-      if (!excludedProps.includes(prop) &&
+      if (excludedProps.indexOf(prop) < 0 &&
           typeof DecoratedComponent[prop] === 'function' &&
           !ConnectToStoresWrapper[prop]) {
         const staticMethod = DecoratedComponent[prop];


### PR DESCRIPTION
Hello,

This PR removes Array.prototype.includes for cross-browser support.

An alternative fix is to have people include a polyfill.

Thoughts?
