### PR TITLE
Feature/get proptypes from package

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ render(<AltContainer flux={ new Flux() }><App /></AltContainer>);
 ***This is the most performant way, it only listen for the specific store changes and not waiting for all stores to update***
 
 ```javascript
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import connect from 'connect-alt';
 
 @connect('session')
@@ -49,7 +50,8 @@ You can pass as many stores you want to the decorator: `@connect('session', 'pos
 ***Warning, this is expensive because `connect-alt` will be listening for any stores update and not the only concerned***
 
 ```javascript
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import connect from 'connect-alt';
 
 @connect(({ session: { currentUser } }) => ({ currentUser }))
@@ -89,7 +91,8 @@ export default Flux;
 #### III. (Alternative 2) Combine the stores you listen and the FinalStore reducer
 
 ```javascript
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import connect from 'connect-alt';
 
 @connect('session', ({ session: { currentUser } }) => ({ currentUser }))

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "tape": "^4.2.2"
   },
   "dependencies": {
+    "prop-types": "^15.6.0",
     "react-pure-render": "^1.0.2"
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
 import PureComponent from 'react-pure-render/component';
 
 // Default `fn` property names


### PR DESCRIPTION
# What does this PR do? 

Remove react warnings when you're using `propTypes` from the `React` package based on the  [migration guide](https://reactjs.org/blog/2017/04/07/react-v15.5.0.html#migrating-from-reactproptypes). 

With this update, we can migrate easier to the react latest version. 

